### PR TITLE
Add/update setup scripts setup.sh and env.sh

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,34 +1,42 @@
+#!/bin/sh
+#
+# The purpose of this script is to setup the environment for the Orocos Toolchain
+# (like setup.sh) and execute a command.
+#
+# Usage: env.sh COMMANDS
+#
+# This file will be installed to CMAKE_INSTALL_PREFIX by cmake with the
+# @-references replaced by the value of the respective cmake variable.
+#
 
-RUBY_VERSION=`ruby --version | awk '{ print $2; }' | sed -e "s/\(.*\..*\)\..*/\1/"`
-RUBY_ARCH=`ruby --version | sed -e 's/.*\[\(.*\)\]/\1/'`
-export RUBYOPT=-rubygems
-export TYPELIB_USE_GCCXML=1
-
-
-if [ x$ROS_ROOT != x ]; then
-### ROS
-export RUBYLIB=`rospack find utilrb`/lib:`rospack find orogen`/lib:`rosstack find orocos_toolchain`/install/lib/ruby/${RUBY_VERSION}/${RUBY_ARCH}:`rosstack find orocos_toolchain`/install/lib/ruby/${RUBY_VERSION}
-export GEM_HOME=`rosstack find orocos_toolchain`/.gems
-export PATH=`rosstack find orocos_toolchain`/install/bin:`rospack find orogen`/bin:`rosstack find orocos_toolchain`/.gems/bin:$PATH
-export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:`rosstack find orocos_toolchain`/install/lib/pkgconfig
-
-elif [ x${BASH} != x ]; then
-### Bash non-ROS
-cd `dirname ${BASH_SOURCE[0]}`
-envpath=$PWD
-cd - > /dev/null
-export RUBYLIB=$envpath/utilrb/lib:$envpath/orogen/lib:$envpath/install/lib/ruby/${RUBY_VERSION}/${RUBY_ARCH}:$envpath/install/lib/ruby/${RUBY_VERSION}
-export GEM_HOME=$envpath/.gems
-export PATH=$envpath/install/bin:$envpath/orogen/bin:$envpath/.gems/bin:$PATH
-export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:$envpath/install/lib/pkgconfig
-
-elif [ `basename $PWD` = orocos_toolchain ]; then
-### non-Bash, non-ROS
-export RUBYLIB=$PWD/utilrb/lib:$PWD/orogen/lib:$PWD/install/lib/ruby/${RUBY_VERSION}/${RUBY_ARCH}:$PWD/install/lib/ruby/${RUBY_VERSION}
-export GEM_HOME=$PWD/.gems
-export PATH=$PWD/install/bin:$PWD/orogen/bin:$PWD/.gems/bin:$PATH
-export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:$PWD/install/lib/pkgconfig
-else
-  echo "Error: This script must be sourced from the 'orocos_toolchain' directory when not running in a ROS_ROOT nor bash environment."
-  echo  
+if [ $# -eq 0 ] ; then
+  if [ -z "$BASH_SOURCE" -a -z "$_" ]; then
+    /bin/echo "Usage: env.sh COMMANDS" >&2
+    exit 1
+  fi
 fi
+
+# find OROCOS installation folder from CMAKE_INSTALL_PREFIX or $0
+case "@CMAKE_INSTALL_PREFIX@" in
+  @*) ;;
+  *)  OROCOS_INSTALL_PREFIX="@CMAKE_INSTALL_PREFIX@" ;;
+esac
+if [ -z "$OROCOS_INSTALL_PREFIX" ]; then
+  OROCOS_INSTALL_PREFIX=`dirname $0`
+  OROCOS_INSTALL_PREFIX=`cd ${OROCOS_INSTALL_PREFIX}; pwd`
+fi
+
+# source setup.sh
+if [ -f ${OROCOS_INSTALL_PREFIX}/setup.sh ]; then
+  . ${OROCOS_INSTALL_PREFIX}/setup.sh
+elif [ -f ${OROCOS_INSTALL_PREFIX}/etc/orocos/setup.sh ]; then
+  . ${OROCOS_INSTALL_PREFIX}/etc/orocos/setup.sh
+elif [ -f /etc/orocos/setup.sh ]; then
+  . /etc/orocos/setup.sh
+else
+  echo "env.sh: could not find Orocos setup.sh script" >&2
+  [ $# -eq 0 ] || exit 1
+fi
+
+# execute command
+[ $# -eq 0 ] || exec "$@"

--- a/orocos_toolchain/CMakeLists.txt
+++ b/orocos_toolchain/CMakeLists.txt
@@ -1,4 +1,59 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(orocos_toolchain)
-find_package(catkin REQUIRED)
-catkin_metapackage()
+
+find_package(catkin QUIET)
+if(catkin_FOUND)
+  catkin_metapackage()
+
+else()
+  install(FILES
+    package.xml
+    DESTINATION share/${PROJECT_NAME}/
+  )
+endif()
+
+# need to find Orocos RTT to set OROCOS_TARGET and other cmake variables
+find_package(OROCOS-RTT REQUIRED)
+
+set(OROCOS_SETUP_DESTINATION "etc/orocos" CACHE STRING "Destination folder for Orocos setup files (setup.sh, env.sh), relative to CMAKE_INSTALL_PREFIX")
+configure_file(../setup.sh ${CMAKE_CURRENT_BINARY_DIR}/setup.sh @ONLY)
+configure_file(../env.sh ${CMAKE_CURRENT_BINARY_DIR}/env.sh @ONLY)
+
+if(OROCOS_SETUP_DESTINATION)
+  install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/setup.sh"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/${OROCOS_SETUP_DESTINATION}"
+  )
+  install(PROGRAMS
+    "${CMAKE_CURRENT_BINARY_DIR}/env.sh"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/${OROCOS_SETUP_DESTINATION}"
+  )
+endif()
+
+# Install setup files directly to CMAKE_INSTALL_PREFIX if we are not
+# installing to a default location, but do not override setup files
+# installed by catkin or when building a binary package using bloom.
+if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT
+   AND NOT CMAKE_INSTALL_PREFIX STREQUAL "/usr"
+   AND NOT CMAKE_INSTALL_PREFIX STREQUAL "/usr/local"
+   AND NOT CATKIN_BUILD_BINARY_PACKAGE)
+  install(CODE "
+    if(NOT EXISTS \"\${CMAKE_INSTALL_PREFIX}/setup.sh\")
+      file(INSTALL
+        \"${CMAKE_CURRENT_BINARY_DIR}/setup.sh\"
+        DESTINATION \"\${CMAKE_INSTALL_PREFIX}\"
+      )
+    else()
+      message(STATUS \"Keeping original: \${CMAKE_INSTALL_PREFIX}/setup.sh\")
+    endif()
+    if(NOT EXISTS \"\${CMAKE_INSTALL_PREFIX}/env.sh\")
+      file(INSTALL
+        \"${CMAKE_CURRENT_BINARY_DIR}/env.sh\"
+        DESTINATION \"\${CMAKE_INSTALL_PREFIX}\"
+        FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+      )
+    else()
+      message(STATUS \"Keeping original: \${CMAKE_INSTALL_PREFIX}/env.sh\")
+    endif()
+  ")
+endif()

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+#
+# The purpose of this script is to setup the environment for the Orocos Toolchain.
+#
+# Usage: . @CMAKE_INSTALL_PREFIX@/@OROCOS_SETUP_DESTINATION@/setup.sh
+#
+# This file will be installed to CMAKE_INSTALL_PREFIX by cmake with the
+# @-references replaced by the value of the respective cmake variable.
+#
+
+# find OROCOS installation folder from CMAKE_INSTALL_PREFIX, BASH_SOURCE or $_
+case "@CMAKE_INSTALL_PREFIX@" in
+  @*) ;;
+  *)  OROCOS_INSTALL_PREFIX="@CMAKE_INSTALL_PREFIX@" ;;
+esac
+if [ -z "$OROCOS_INSTALL_PREFIX" ]; then
+  if [ -n "$BASH_SOURCE" ]; then
+    OROCOS_INSTALL_PREFIX=`dirname ${BASH_SOURCE[0]}`
+    OROCOS_INSTALL_PREFIX=`cd ${OROCOS_INSTALL_PREFIX}; pwd`
+  elif [ -n "$_" ]; then
+    OROCOS_INSTALL_PREFIX=`dirname $_`
+    OROCOS_INSTALL_PREFIX=`cd ${OROCOS_INSTALL_PREFIX}; pwd`
+  else
+    echo "Could not determine the OROCOS installation prefix for your shell." >&2
+    exit 1
+  fi
+fi
+
+# initialize OROCOS_TARGET if unset
+if [ -z "${OROCOS_TARGET}" ]; then
+  case "@OROCOS_TARGET@" in
+    @*) ;;
+    *)  OROCOS_TARGET="@OROCOS_TARGET@" ;;
+  esac
+fi
+
+# add bin/ to PATH
+if [ -d ${OROCOS_INSTALL_PREFIX}/bin ]; then
+  if ! echo $PATH | grep -q "${OROCOS_INSTALL_PREFIX}/bin"; then
+    PATH="${PATH}:${OROCOS_INSTALL_PREFIX}/bin"
+  fi
+fi
+
+# add OROCOS_INSTALL_PREFIX to CMAKE_PREFIX_PATH
+if [ -d ${OROCOS_INSTALL_PREFIX} ]; then
+  if ! echo $CMAKE_PREFIX_PATH | grep -q "${OROCOS_INSTALL_PREFIX}"; then
+    if [ -z "$CMAKE_PREFIX_PATH" ]; then
+      CMAKE_PREFIX_PATH="${OROCOS_INSTALL_PREFIX}"
+    else
+      CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:${OROCOS_INSTALL_PREFIX}"
+    fi
+  fi
+fi
+
+# add lib/orocos to RTT_COMPONENT_PATH
+# Note: The rtt env-hook also sets the RTT_COMPONENT_PATH variable. We could
+# remove this redundant section.
+if [ -d ${OROCOS_INSTALL_PREFIX}/lib/orocos ]; then
+  if ! echo $RTT_COMPONENT_PATH | grep -q "${OROCOS_INSTALL_PREFIX}/lib/orocos"; then
+    if [ -z "$RTT_COMPONENT_PATH" ]; then
+      RTT_COMPONENT_PATH="${OROCOS_INSTALL_PREFIX}/lib/orocos"
+    else
+      RTT_COMPONENT_PATH="${RTT_COMPONENT_PATH}:${OROCOS_INSTALL_PREFIX}/lib/orocos"
+    fi
+  fi
+fi
+
+# add lib/pkgconfig to PKG_CONFIG_PATH
+if [ -d ${OROCOS_INSTALL_PREFIX}/lib/pkgconfig ]; then
+  if ! echo $PKG_CONFIG_PATH | grep -q "${OROCOS_INSTALL_PREFIX}/lib/pkgconfig"; then
+    if [ -z "$PKG_CONFIG_PATH" ]; then
+      PKG_CONFIG_PATH="${OROCOS_INSTALL_PREFIX}/lib/pkgconfig"
+    else
+      PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:${OROCOS_INSTALL_PREFIX}/lib/pkgconfig"
+    fi
+  fi
+fi
+
+# find and source target-specific env-hooks in etc/orocos/profile.d
+for hook in ${OROCOS_INSTALL_PREFIX}/etc/orocos/profile.d/*.sh; do
+  [ -f $hook ] && . ${hook}
+done
+
+# export environment variables
+export OROCOS_INSTALL_PREFIX
+export OROCOS_TARGET
+export PATH
+export CMAKE_PREFIX_PATH
+export RTT_COMPONENT_PATH
+export PKG_CONFIG_PATH


### PR DESCRIPTION
Only the setup scripts part of #13.

The setup scripts will set the required environment variables to run Orocos RTT and other toolchain
packages. The actual env-hooks have been moved into the individual packages that need it:

- https://github.com/orocos-toolchain/rtt/pull/160
- https://github.com/orocos-toolchain/ocl/pull/43
- https://github.com/orocos-toolchain/utilrb/commit/8ac984f2278dc8ade750bf506ff03f11c11e6ea2#diff-47236f28d8c7e670852c13dcc723ed57
- https://github.com/orocos-toolchain/typelib/commit/d4779e6810d846f34ae560a3d1c9eed959f7b944