### PR TITLE
Add top-level CMakeLists.txt, configure script and Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+install/

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
   include:
     - os: linux
       dist: xenial
-      env: COMPILER=gcc CXXFLAGS="-std=c++03 -Wall -Wextra -Wno-unused-parameter"
+      env: COMPILER=gcc CXXFLAGS="-std=gnu++03 -Wall -Wextra -Wno-unused-parameter"
     - os: linux
       dist: xenial
       env: COMPILER=gcc CXXFLAGS="-std=c++11 -Wall -Wextra -Wno-unused-parameter"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,74 @@
+language: generic
+cache: ccache
+
+addons:
+  apt:
+    packages:
+      - build-essential
+      - git
+      - cmake
+      - libboost-all-dev
+      - libxml-xpath-perl
+      - libboost-all-dev
+      - omniorb
+      - omniidl
+      - omniorb-nameserver
+      - libomniorb4-dev
+      - pkg-config
+      - clang-3.8
+
+env:
+  global:
+    - BOOST_TEST_LOG_LEVEL=message
+    - CFLAGS="-Wall -Wextra -Wno-unused-parameter"
+
+matrix:
+  include:
+    - os: linux
+      dist: xenial
+      env: COMPILER=gcc CXXFLAGS="-std=c++03 -Wall -Wextra -Wno-unused-parameter"
+    - os: linux
+      dist: xenial
+      env: COMPILER=gcc CXXFLAGS="-std=c++11 -Wall -Wextra -Wno-unused-parameter"
+    - os: linux
+      dist: xenial
+      env: COMPILER=clang-3.8 CXXFLAGS="-std=c++11 -Wall -Wextra -Wno-unused-parameter"
+    - os: linux
+      dist: xenial
+      env: COMPILER=clang CXXFLAGS="-std=c++11 -Wall -Wextra -Wno-unused-parameter"
+    - os: osx
+      osx_image: xcode10.1
+
+branches:
+  only:
+  - master
+  - /^toolchain-[\d\.]+[\d]$/
+
+before_install:
+  # Set C/C++ compiler
+  - |
+    if [[ "${COMPILER}" != "" ]]; then
+      export CC=${COMPILER}
+      if [[ "${COMPILER}" == "gcc"* ]]; then
+        export CXX=${COMPILER/gcc/g++}
+      elif [[ "${COMPILER}" == "clang"* ]]; then
+        export CXX=${COMPILER/clang/clang++}
+      fi
+      ${CC} --version
+      ${CXX} --version
+    fi
+
+  # Install HomeBrew dependencies (macOS only)
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      brew update
+      brew reinstall boost cmake ccache gnu-getopt readline omniorb
+      brew link --force gnu-getopt
+      brew link --force readline
+      export PATH="/use/local/opt/ccache/libexec:$PATH"
+    fi
+
+script:
+  # Build and install the Orocos Toolchain
+  - ./configure --enable-corba --omniorb
+  - make -j2 install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,23 +91,8 @@ else()
 endif()
 
 set(GIT_BASE_URL "https://github.com/orocos-toolchain/")
-#set(GIT_TAG "" CACHE STRING "Git branch or tag to checkout in submodules. Default to current branch (update) or default branch (clone).")
+set(GIT_TAG "" CACHE STRING "Git branch or tag to checkout in submodules. If empty, use the commits tracked by submodules or the default branches.")
 
-# Find current branch if this is a git tree and use it as a default.
-if(IS_GIT)
-  execute_process(
-    COMMAND git --git-dir=${CMAKE_CURRENT_SOURCE_DIR}/.git symbolic-ref --short HEAD
-    OUTPUT_VARIABLE CURRENT_GIT_BRANCH
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_QUIET
-  )
-  if(CURRENT_GIT_BRANCH)
-    message(STATUS "Current orocos_toolchain branch: ${CURRENT_GIT_BRANCH}")
-    if(NOT DEFINED GIT_TAG)
-      set(GIT_TAG ${CURRENT_GIT_BRANCH})  # not cached!
-    endif()
-  endif()
-endif()
 if(GIT_TAG)
   message(STATUS "Building branch or tag ${GIT_TAG} for all submodules.")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,207 @@
+##
+## Top-level CMakeLists.txt to build and install the whole Orocos Toolchain
+##
+
+cmake_minimum_required(VERSION 2.8)
+
+# capture CMake arguments specified at the command-line
+# (taken from https://stackoverflow.com/a/48555098)
+
+# MUST be done before call to 'project'
+get_cmake_property(vars CACHE_VARIABLES)
+foreach(var ${vars})
+  if(NOT var MATCHES "^(CMAKE_INSTALL_PREFIX|CMAKE_BUILD_TYPE|GIT_BASE_URL|GIT_TAG|OROCOS_TARGET|BUILD_STATIC|ENABLE_CORBA|CORBA_IMPLEMENTATION)$")
+    get_property(currentHelpString CACHE "${var}" PROPERTY HELPSTRING)
+    if("${currentHelpString}" MATCHES "No help, variable specified on the command line." OR "${currentHelpString}" STREQUAL "")
+      #message("${var} = [${${var}}]  --  ${currentHelpString}") # uncomment to see the variables being processed
+      list(APPEND CL_ARGS "-D${var}=${${var}}")
+    endif()
+  endif()
+endforeach()
+
+project(orocos_toolchain)
+
+######################
+# Build-time options #
+######################
+
+# get absolute CMAKE_INSTALL_PREFIX
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/install")
+endif()
+set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}" CACHE PATH "Install path prefix, prepended onto install directories" FORCE)
+message(STATUS "CMAKE_INSTALL_PREFIX: ${CMAKE_INSTALL_PREFIX}")
+
+# (copied from rtt/orocos-rtt.default.cmake)
+
+#
+# Sets the CMAKE_BUILD_TYPE to Release by default. This is not a normal
+# CMake flag which is not readable during configuration time.
+if (NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Choose the type of build, options are: None(CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel." FORCE)
+endif()
+
+#
+# Set the target operating system. One of [lxrt gnulinux xenomai macosx win32]
+# You may leave this as-is or force a certain target by removing the if... logic.
+#
+set(DOC_STRING "The Operating System target. One of [gnulinux lxrt macosx win32 xenomai]")
+set(OROCOS_TARGET_ENV $ENV{OROCOS_TARGET}) # MUST use helper variable, otherwise not picked up !!!
+if( OROCOS_TARGET_ENV )
+  set(OROCOS_TARGET ${OROCOS_TARGET_ENV} CACHE STRING "${DOC_STRING}" FORCE)
+  message(STATUS "Detected OROCOS_TARGET environment variable. Using: ${OROCOS_TARGET}")
+else()
+  if(NOT DEFINED OROCOS_TARGET )
+    if(MSVC)
+      set(OROCOS_TARGET win32    CACHE STRING "${DOC_STRING}")
+    elseif(APPLE AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+      set(OROCOS_TARGET macosx   CACHE STRING "${DOC_STRING}")
+    else()
+      set(OROCOS_TARGET gnulinux CACHE STRING "${DOC_STRING}")
+    endif()
+  endif()
+  message(STATUS "No OROCOS_TARGET environment variable set. Using: ${OROCOS_TARGET}")
+endif()
+
+# (copied from rtt/config/check_depend.cmake)
+
+#
+# Build static libraries?
+#
+option(BUILD_STATIC "Build Orocos RTT as a static library." OFF)
+
+#
+# CORBA
+#
+option(ENABLE_CORBA "Enable CORBA" OFF)
+if(NOT CORBA_IMPLEMENTATION)
+  set(CORBA_IMPLEMENTATION "TAO" CACHE STRING "The implementation of CORBA to use (allowed values: TAO or OMNIORB )" )
+else()
+  set(CORBA_IMPLEMENTATION ${CORBA_IMPLEMENTATION} CACHE STRING "The implementation of CORBA to use (allowed values: TAO or OMNIORB )" )
+endif()
+
+#############
+# Git magic #
+#############
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+  set(IS_GIT TRUE)
+else()
+  set(IS_GIT FALSE)
+endif()
+
+set(GIT_BASE_URL "https://github.com/orocos-toolchain/")
+#set(GIT_TAG "" CACHE STRING "Git branch or tag to checkout in submodules. Default to current branch (update) or default branch (clone).")
+
+# Find current branch if this is a git tree and use it as a default.
+if(IS_GIT)
+  execute_process(
+    COMMAND git --git-dir=${CMAKE_CURRENT_SOURCE_DIR}/.git symbolic-ref --short HEAD
+    OUTPUT_VARIABLE CURRENT_GIT_BRANCH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+  if(CURRENT_GIT_BRANCH)
+    message(STATUS "Current orocos_toolchain branch: ${CURRENT_GIT_BRANCH}")
+    if(NOT DEFINED GIT_TAG)
+      set(GIT_TAG ${CURRENT_GIT_BRANCH})  # not cached!
+    endif()
+  endif()
+endif()
+if(GIT_TAG)
+  message(STATUS "Building branch or tag ${GIT_TAG} for all submodules.")
+endif()
+
+#################################
+# Build and install subprojects #
+#################################
+
+include(ExternalProject)
+function(build_external_project project)
+  cmake_parse_arguments(ARG "" "" "CMAKE_ARGS" ${ARGN})
+
+  set(${project}_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${project})
+  set(${project}_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${project})
+
+  if(IS_GIT)
+    # Use the submodules...
+    set(DOWNLOAD_AND_UPDATE_OPTIONS
+      DOWNLOAD_COMMAND
+        cd "${CMAKE_CURRENT_SOURCE_DIR}" && test -e ${project}/.git || git submodule update --init ${project}
+    )
+
+    # Specific branch/tag?
+    if(GIT_TAG)
+      list(APPEND DOWNLOAD_AND_UPDATE_OPTIONS
+        UPDATE_COMMAND
+          cd "${CMAKE_CURRENT_SOURCE_DIR}/${project}" && git checkout "${GIT_TAG}"
+      )
+    endif()
+
+  else()
+    # Clone from remote repository...
+    set(DOWNLOAD_AND_UPDATE_OPTIONS
+      GIT_REPOSITORY "${GIT_BASE_URL}${project}.git"
+      GIT_TAG "${GIT_TAG}"
+    )
+  endif()
+
+  # Set PKG_CONFIG_PATH to be used by subprojects
+  set(PKG_CONFIG_PATH "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+
+  ExternalProject_Add(${project}
+    PREFIX ${project}
+    TMP_DIR "${CMAKE_CURRENT_BINARY_DIR}/tmp"
+    STAMP_DIR "${CMAKE_CURRENT_BINARY_DIR}/stamp"
+    DOWNLOAD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/${project}"
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/${project}"
+    BINARY_DIR "${${project}_BINARY_DIR}"
+    INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
+
+    ${DOWNLOAD_AND_UPDATE_OPTIONS}
+    PATCH_COMMAND #nothing
+    BUILD_ALWAYS ON
+
+    CMAKE_COMMAND
+      ${CMAKE_COMMAND} -E env "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}" ${CMAKE_COMMAND}
+
+    CMAKE_ARGS
+      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+      -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+      -DOROCOS_TARGET=${OROCOS_TARGET}
+      ${ARG_CMAKE_ARGS}
+
+    ${ARG_UNPARSED_ARGUMENTS}
+  )
+endfunction()
+
+build_external_project(log4cpp)
+build_external_project(rtt
+  CMAKE_ARGS
+    -DENABLE_CORBA=${ENABLE_CORBA}
+    -DCORBA_IMPLEMENTATION=${CORBA_IMPLEMENTATION}
+    -DBUILD_STATIC=${BUILD_STATIC}
+)
+build_external_project(ocl
+  DEPENDS log4cpp rtt
+)
+
+build_external_project(utilrb)
+build_external_project(typelib
+  DEPENDS utilrb
+)
+build_external_project(rtt_typelib
+  DEPENDS typelib
+)
+build_external_project(orogen
+  DEPENDS rtt rtt_typelib utilrb
+)
+
+#######################################
+# Build orocos_toolchain meta package #
+#######################################
+
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/orocos_toolchain)
+  add_subdirectory(orocos_toolchain)
+endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,7 @@ build_external_project(typelib
   DEPENDS utilrb
 )
 build_external_project(rtt_typelib
-  DEPENDS typelib
+  DEPENDS rtt typelib
 )
 build_external_project(orogen
   DEPENDS rtt rtt_typelib utilrb

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: all install
+all: build/CMakeCache.txt
+	$(MAKE) -C build $@
+
+build/CMakeCache.txt: configure
+
+configure:
+	./configure
+.PHONY: configure
+
+install: all
+.PHONY: install
+
+.DEFAULT: build/CMakeCache.txt
+	$(MAKE) -C build $@
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,76 @@
+# The Orocos Toolchain
+
+The Open RObot COntrol Software ([Orocos](http://www.orocos.org/)) Toolchain is a bundle of multiple packages, which need to be build and installed separately.
+
+- [Orocos Real-Time Toolkit (rtt)](https://github.com/orocos-toolchain/rtt) - a component framework that allows us to write real-time components in C++
+- [Orocos Log4cpp (log4cpp)](https://github.com/orocos-toolchain/log4cpp) -
+  a patched version of the [Log4cpp](http://log4cpp.sourceforge.net/) library for flexible logging to files, syslog, IDSA and other destinations
+- [Orocos Component Library (ocl)](https://github.com/orocos-toolchain/ocl) - the necessary components to start an application and interact with it at run-time
+
+Futhermore the Orocos Toolchain comes with [oroGen](http://www.rock-robotics.org/stable/documentation/orogen/) and some of its dependencies,
+a specification language and code generator for the Orocos Realtime Toolkit. Also check the installation instructions of the
+[Rock - the Robot Construction Kit](http://www.rock-robotics.org/stable/index.html) project for further details.
+
+You might also want to have a look at the following sister projects, which are out of the scope of this manual:
+- [Orocos Kinematics Dynamics Library (KDL)](http://www.orocos.org/kdl) - an application independent framework for modeling and computation of kinematic chains
+- [Orocos Bayesian Filtering Library (BFL)](http://www.orocos.org/bfl) - an application independent framework for inference in Dynamic Bayesian Networks, i.e., recursive information processing and estimation algorithms based on Bayes' rule
+- [Reduced Finite State Machine (rFSM)](https://orocos.github.io/rFSM/README.html) - a small and powerful statechart implementation in Lua
+
+## Documentation
+
+The latest documentation and API reference is currently available at https://orocos-toolchain.github.io/.
+
+## Get Started?
+
+### Install binary packages
+
+The Orocos project provides binary packages as part of the [ROS distribution](http://www.ros.org) for various platforms.
+Check and follow the [ROS installation instructions](http://wiki.ros.org/ROS/Installation), then run
+```sh
+sudo apt-get install ros-${ROS_DISTRO}-orocos-toolchain
+```
+
+to install the Orocos Toolchain packages.
+
+As a ROS user, you might also be interested in the [rtt_ros_integration](http://wiki.ros.org/rtt_ros_integration) project:
+```sh
+sudo apt-get install ros-${ROS_DISTRO}-rtt-ros-integration
+```
+
+### Build the toolchain from source
+
+First, clone this repository and its submodules with the command
+```sh
+git clone https://github.com/orocos-toolchain/orocos_toolchain.git --recursive
+```
+
+If you already have a working copy, make sure that all submodules are up-to-date:
+```sh
+git submodule update --init --recursive
+```
+
+The next step is to configure the toolchain according to your needs:
+```sh
+./configure --prefix=<installation prefix> [<options>]
+```
+
+```sh
+Usage: ./configure [<options>] [<additional cmake arguments>]
+
+Available options:
+
+  --prefix <prefix>        Installation prefix (-DCMAKE_INSTALL_PREFIX)
+
+  --{en|dis}able-corba     Enable/Disable CORBA transport plugin (-DENABLE_CORBA)
+  --omniorb                Select CORBA implementation OmniORB
+  --tao                    Select CORBA implementation TAO
+```
+
+`configure` is nothing else than a simple wrapper around [CMake](https://cmake.org/).
+Check `./configure --help` for the latest available options.
+
+Last but not least, build the toolchain by running
+```sh
+make install [-j<parallel jobs>]
+```
+

--- a/configure
+++ b/configure
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+##
+usage() {
+  cat <<USAGE >&2
+Usage: $0 [<options>] [<additional cmake arguments>]
+
+Available options:
+
+  --prefix <prefix>        Installation prefix (-DCMAKE_INSTALL_PREFIX)
+
+  --{en|dis}able-corba     Enable/Disable CORBA transport plugin (-DENABLE_CORBA)
+  --omniorb                Select CORBA implementation OmniORB
+  --tao                    Select CORBA implementation TAO
+
+USAGE
+  exit 1
+}
+
+## Parse command line arguments
+CMAKE_ARGS=()
+while (( "$#" )); do
+  case "$1" in
+    --help|-h)
+      usage ;;
+
+    --prefix=*)
+      # set as two separate options
+      prefix=${1#--prefix=}
+      shift
+      set -- --prefix "${prefix}" "$@"
+      ;;
+
+    --prefix)
+      CMAKE_ARGS+=("-DCMAKE_INSTALL_PREFIX=$2")
+      shift 2 ;;
+
+    --enable-corba)
+      CMAKE_ARGS+=("-DENABLE_CORBA=ON")
+      shift ;;
+    --disable-corba)
+      CMAKE_ARGS+=("-DENABLE_CORBA=OFF")
+      shift ;;
+    --omniorb)
+      CMAKE_ARGS+=("-DCORBA_IMPLEMENTATION=OMNIORB")
+      shift ;;
+    --tao)
+      CMAKE_ARGS+=("-DCORBA_IMPLEMENTATION=TAO")
+      shift ;;
+
+    *)
+      CMAKE_ARGS+=("$1")
+      shift ;;
+  esac
+done
+
+## Invoke cmake
+mkdir -p build && cd build && cmake .. "${CMAKE_ARGS[@]}"
+

--- a/orocos_toolchain/CMakeLists.txt
+++ b/orocos_toolchain/CMakeLists.txt
@@ -12,8 +12,23 @@ else()
   )
 endif()
 
-# need to find Orocos RTT to set OROCOS_TARGET and other cmake variables
-find_package(OROCOS-RTT REQUIRED)
+# Set the default target operating system, if unspecified
+set(DOC_STRING "The Operating System target. One of [gnulinux lxrt macosx win32 xenomai]")
+set(OROCOS_TARGET_ENV $ENV{OROCOS_TARGET}) # MUST use helper variable, otherwise not picked up !!!
+if(OROCOS_TARGET_ENV)
+  set(OROCOS_TARGET ${OROCOS_TARGET_ENV} CACHE STRING "${DOC_STRING}" FORCE)
+  message(STATUS "- Detected OROCOS_TARGET environment variable. Using: ${OROCOS_TARGET}")
+else()
+  if(NOT DEFINED OROCOS_TARGET)
+    if(MSVC)
+      set(OROCOS_TARGET win32    CACHE STRING "${DOC_STRING}")
+    elseif(APPLE AND CMAKE_SYSTEM_NAME MATCHES "Darwin")
+      set(OROCOS_TARGET macosx   CACHE STRING "${DOC_STRING}")
+    else()
+      set(OROCOS_TARGET gnulinux CACHE STRING "${DOC_STRING}")
+    endif()
+  endif()
+endif()
 
 set(OROCOS_SETUP_DESTINATION "etc/orocos" CACHE STRING "Destination folder for Orocos setup files (setup.sh, env.sh), relative to CMAKE_INSTALL_PREFIX")
 configure_file(../setup.sh ${CMAKE_CURRENT_BINARY_DIR}/setup.sh @ONLY)


### PR DESCRIPTION
Follow-up of #13. Partially addresses #27, #30, #32, ...

Obvously we also have to update the website http://www.orocos.org/, because lots of information found there is actually outdated.

Instead of a complex and hard to maintain shell script (#13) I propose to use CMake's powerful [ExternalProject](https://cmake.org/cmake/help/v3.0/module/ExternalProject.html) module to build and install the individual subprojects in their own build directories in the correct dependency order.

[AutoProj](https://www.rock-robotics.org/documentation/autoproj/) never really worked for me, partially because it depended on newer Ruby versions than the ones available with Ubuntu LTS releases. But I have to admit that I have not tried recently. A pure CMake approach seems to be more appropriate for most users. Installation of dependencies is left to the user (still needs more detailed documentation). But of course I am open to also add or link instructions on how to optionally build the toolchain with AutoProj.

By default the current CMake config tries to checkout the branches with the same name as the current branch in the `orocos_toolchain` repo. This can be overwritten by adding `-DGIT_TAG=<branch or tag>` to the `configure` script or directly to `cmake`.

For non-ROS users the patch also requires #33 because the current version of [orocos_toolchain/CMakeLists.txt](https://github.com/orocos-toolchain/orocos_toolchain/blob/cmake-external-project/orocos_toolchain/CMakeLists.txt) depends on `catkin` and configuration fails if `catkin` cannot be found in the `CMAKE_PREFIX_PATH`. ROS users would probably build and install with `catkin_make_isolated` or [catkin_tools](https://catkin-tools.readthedocs.io/en/latest/) instead, so the new top-level CMake config and scripts are of limited use.