### PR TITLE
Add CMake option BUILD_OROGEN and update metapackage manifest to format 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,11 @@ else()
   set(CORBA_IMPLEMENTATION ${CORBA_IMPLEMENTATION} CACHE STRING "The implementation of CORBA to use (allowed values: TAO or OMNIORB )" )
 endif()
 
+#
+# Enable/disable orogen and dependencies
+#
+option(BUILD_OROGEN "Build orogen and its dependencies" OFF)
+
 #############
 # Git magic #
 #############
@@ -171,16 +176,18 @@ build_external_project(ocl
   DEPENDS log4cpp rtt
 )
 
-build_external_project(utilrb)
-build_external_project(typelib
-  DEPENDS utilrb
-)
-build_external_project(rtt_typelib
-  DEPENDS rtt typelib
-)
-build_external_project(orogen
-  DEPENDS rtt rtt_typelib utilrb
-)
+if(BUILD_OROGEN)
+  build_external_project(utilrb)
+  build_external_project(typelib
+    DEPENDS utilrb
+  )
+  build_external_project(rtt_typelib
+    DEPENDS rtt typelib
+  )
+  build_external_project(orogen
+    DEPENDS rtt rtt_typelib utilrb
+  )
+endif()
 
 #######################################
 # Build orocos_toolchain meta package #

--- a/orocos_toolchain/package.xml
+++ b/orocos_toolchain/package.xml
@@ -1,26 +1,23 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>orocos_toolchain</name>
   <version>2.9.0</version>
   <description>
-    This package provides the entire orocos_toolchain
+    This metapackage provides Orocos RTT and OCL and dependencies.
   </description>
-  <maintainer email="orocos-dev@lists.mech.kuleuven.be">Orocos Developers</maintainer>
-  <license>GPL v2 + linking exception, LGPL v2, CeCILL-B, GPL v2 or later, </license>
+  <license>GPL v2 + linking exception<license>
+  <licence>LGPL-2.1</license>
+  <maintainer email="orocos-dev@orocos.org">Orocos Developers</maintainer>
 
-  <buildtool_depend>catkin</buildtool_depend>
-  <run_depend>catkin</run_depend>
+  <buildtool_depend>catkin</buildtool_depend> <!-- optional -->
 
-  <run_depend>rtt</run_depend>
-  <run_depend>ocl</run_depend>
-  <run_depend>log4cpp</run_depend>
-  <run_depend>rtt_typelib</run_depend>
-  <run_depend>typelib</run_depend>
-  <run_depend>utilrb</run_depend>
-  <run_depend>orogen</run_depend>
+  <depend>log4cpp</depend>
+  <depend>ocl</depend>
+  <depend>rtt</depend>
 
   <export>
     <metapackage/>
   </export>
 
 </package>
-


### PR DESCRIPTION
https://github.com/orocos-toolchain/orocos_toolchain/pull/34 added a new top-level `CMakeLists.txt` to build the toolchain packages with CMake and [ExternalProject](https://cmake.org/cmake/help/v3.0/module/ExternalProject.html).

Not all Orocos users require [orogen](https://github.com/orocos-toolchain/orogen), which brings in Ruby and other dependencies. Furthermore dependency `utilrb` depends on `metaruby` (https://github.com/rock-core/tools-metaruby), a package that is not available from default package repositories of common Linux distributions and cannot be built with CMake today. It needs to be installed as a Ruby gem or from source or with [AutoProj](https://github.com/rock-core/autoproj). Splitting off the "core" packages RTT and OCL from orogen and other Ruby dependencies was already suggested in https://github.com/orocos-toolchain/orocos_toolchain/issues/18, without a conclusion yet.

Until a unified way of bootstrapping the toolchain with or without Ruby and optional packages has been implemented, or until it has been decided to remove orogen submodules or even this whole meta-repository, I suggest to disable orogen by default for pure CMake builds that use the top-level `CMakeLists.txt`. For starting on ROS 2 support we would like to have a way to build RTT and OCL without catkin, but also without adding explicit support for new build tools like [colcon](https://index.ros.org/doc/ros2/Tutorials/Colcon-Tutorial/) and [ament_cmake](https://index.ros.org/doc/ros2/Tutorials/Ament-CMake-Documentation/) and without introducing a "new" build tool like [AutoProj](https://github.com/rock-core/autoproj) for ROS users, which would make it impossible to release into the ROS ecosystem.

The `package.xml` file of the `orocos_toolchain` metapackage has been update to format 3, following https://github.com/orocos-toolchain/rtt/pull/321 and https://github.com/orocos-toolchain/ocl/pull/90, with the optional dependencies (and their licenses) removed. The metapackage is relevant for catkin builds only.
