### PR TITLE
Fix macOS build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,8 +63,15 @@ before_install:
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew update
       brew reinstall boost cmake ccache gnu-getopt readline omniorb
-      brew link --force gnu-getopt
-      brew link --force readline
+
+      # gnu-getopt is keg-only and newer HomeBrew versions refuse to link it.
+      #brew link --force gnu-getopt
+      export PATH="/usr/local/opt/gnu-getopt/bin:$PATH"
+
+      # readline is keg-only and newer HomeBrew versions refuse to link it.
+      #brew link --force readline
+      export CMAKE_PREFIX_PATH="/usr/local/opt/readline"
+
       export PATH="/use/local/opt/ccache/libexec:$PATH"
     fi
 


### PR DESCRIPTION
Newer HomeBrew versions seem to refuse to link and show the following output instead:

    Warning: Refusing to link macOS provided/shadowed software: gnu-getopt
    If you need to have gnu-getopt first in your PATH run:
      echo 'export PATH="/usr/local/opt/gnu-getopt/bin:$PATH"' >> /Users/travis/.bash_profile

    Warning: Refusing to link macOS provided/shadowed software: readline
    For compilers to find readline you may need to set:
      export LDFLAGS="-L/usr/local/opt/readline/lib"
      export CPPFLAGS="-I/usr/local/opt/readline/include"

    For pkg-config to find readline you may need to set:
      export PKG_CONFIG_PATH="/usr/local/opt/readline/lib/pkgconfig"

(e.g. https://travis-ci.org/github/orocos-toolchain/orocos_toolchain/jobs/688614120)

As a consequence, OCL fails to build because it includes the BSD libedit headers provided by macOS instead of the readline headers provided by HomeBrew.