### PR TITLE
Update to package.xml format 3 and update maintainer email

### DIFF
--- a/orocos_toolchain/package.xml
+++ b/orocos_toolchain/package.xml
@@ -12,9 +12,9 @@
 
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend> <!-- optional -->
 
-  <depend>log4cpp</depend>
-  <depend>ocl</depend>
-  <depend>rtt</depend>
+  <exec_depend>log4cpp</exec_depend>
+  <exec_depend>ocl</exec_depend>
+  <exec_depend>rtt</exec_depend>
 
   <export>
     <metapackage/>

--- a/orocos_toolchain/package.xml
+++ b/orocos_toolchain/package.xml
@@ -1,26 +1,23 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>orocos_toolchain</name>
   <version>2.9.0</version>
   <description>
-    This package provides the entire orocos_toolchain
+    This metapackage provides Orocos RTT and OCL and dependencies.
   </description>
-  <maintainer email="orocos-dev@lists.mech.kuleuven.be">Orocos Developers</maintainer>
-  <license>GPL v2 + linking exception, LGPL v2, CeCILL-B, GPL v2 or later, </license>
+  <license>GPL v2 + linking exception<license>
+  <licence>LGPL-2.1</license>
+  <maintainer email="orocos-dev@orocos.org">Orocos Developers</maintainer>
 
-  <buildtool_depend>catkin</buildtool_depend>
-  <run_depend>catkin</run_depend>
+  <buildtool_depend>catkin</buildtool_depend> <!-- optional -->
 
-  <run_depend>rtt</run_depend>
-  <run_depend>ocl</run_depend>
-  <run_depend>log4cpp</run_depend>
-  <run_depend>rtt_typelib</run_depend>
-  <run_depend>typelib</run_depend>
-  <run_depend>utilrb</run_depend>
-  <run_depend>orogen</run_depend>
+  <depend>log4cpp</depend>
+  <depend>ocl</depend>
+  <depend>rtt</depend>
 
   <export>
     <metapackage/>
   </export>
 
 </package>
-

--- a/orocos_toolchain/package.xml
+++ b/orocos_toolchain/package.xml
@@ -10,7 +10,7 @@
   <licence>LGPL-2.1</license>
   <maintainer email="orocos-dev@orocos.org">Orocos Developers</maintainer>
 
-  <buildtool_depend>catkin</buildtool_depend> <!-- optional -->
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend> <!-- optional -->
 
   <depend>log4cpp</depend>
   <depend>ocl</depend>

--- a/orocos_toolchain/package.xml
+++ b/orocos_toolchain/package.xml
@@ -4,7 +4,7 @@
   <name>orocos_toolchain</name>
   <version>2.9.0</version>
   <description>
-    This metapackage provides Orocos RTT and OCL and dependencies.
+    This package provides the entire orocos_toolchain
   </description>
   <license>GPL v2 + linking exception</license>
   <license>LGPL-2.1</license>
@@ -14,7 +14,11 @@
 
   <exec_depend>log4cpp</exec_depend>
   <exec_depend>ocl</exec_depend>
+  <exec_depend>orogen</exec_depend>
   <exec_depend>rtt</exec_depend>
+  <exec_depend>rtt_typelib</exec_depend>
+  <exec_depend>typelib</exec_depend>
+  <exec_depend>utilrb</exec_depend>
 
   <export>
     <metapackage/>

--- a/orocos_toolchain/package.xml
+++ b/orocos_toolchain/package.xml
@@ -6,8 +6,8 @@
   <description>
     This metapackage provides Orocos RTT and OCL and dependencies.
   </description>
-  <license>GPL v2 + linking exception<license>
-  <licence>LGPL-2.1</license>
+  <license>GPL v2 + linking exception</license>
+  <license>LGPL-2.1</license>
   <maintainer email="orocos-dev@orocos.org">Orocos Developers</maintainer>
 
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend> <!-- optional -->


### PR DESCRIPTION
Same as https://github.com/orocos-toolchain/rtt/pull/321 and https://github.com/orocos-toolchain/ocl/pull/90:

> Format 3 is the latest specification of ROS package manifests ([REP-0149](https://www.ros.org/reps/rep-0149.html)).

As a [metapackage](http://wiki.ros.org/Metapackages), `orocos_toolchain` must only have run-time dependencies (`<exec_depend>`). The [concept of metapackages has been removed in ROS 2](https://docs.ros.org/en/foxy/Contributing/Migration-Guide.html#metapackages).